### PR TITLE
Fix normalizePath

### DIFF
--- a/src/test/util/path-utils.test.js
+++ b/src/test/util/path-utils.test.js
@@ -5,11 +5,11 @@ const pathUtils = require('@src/util/path-utils');
 
 describe('page-utils', () => {
   describe('.normalizePath', () => {
-    test('should return root path with empty string', () => {
+    test('should return the root path with empty string', () => {
       expect(pathUtils.normalizePath('')).toBe('/');
     });
 
-    test('should return the root page as is', () => {
+    test('should return the root path as is', () => {
       expect(pathUtils.normalizePath('/')).toBe('/');
     });
 

--- a/src/test/util/path-utils.test.js
+++ b/src/test/util/path-utils.test.js
@@ -5,8 +5,12 @@ const pathUtils = require('@src/util/path-utils');
 
 describe('page-utils', () => {
   describe('.normalizePath', () => {
-    test('should rurn root path with empty string', () => {
+    test('should return root path with empty string', () => {
       expect(pathUtils.normalizePath('')).toBe('/');
+    });
+
+    test('should return the root page as is', () => {
+      expect(pathUtils.normalizePath('/')).toBe('/');
     });
 
     test('should add heading slash', () => {

--- a/src/util/path-utils.js
+++ b/src/util/path-utils.js
@@ -90,6 +90,10 @@ function removeTrailingSlash(path) {
  * @memberof pathUtils
  */
 function normalizePath(path) {
+  if (path === '' || path === '/') {
+    return '/';
+  }
+
   const match = matchSlashes(path);
   if (match == null) {
     return '/';


### PR DESCRIPTION
下記のIssueにて問題になった`'/'`を渡した際に`'//'`を返してしまう挙動を修正.
https://github.com/weseek/growi-plugin-attachment-refs/issues/2