### PR TITLE
PageCreateModalを空にするとエラーが出る

### DIFF
--- a/src/util/path-utils.js
+++ b/src/util/path-utils.js
@@ -17,7 +17,10 @@ function matchSlashes(path) {
  * @returns {boolean}
  * @memberof pathUtils
  */
-function hasHeadingSlash(path) {
+ function hasHeadingSlash(path) {
+  if (path == null || path === '') {
+    return false;
+  }
   const match = matchSlashes(path);
   return (match[2] != null);
 }
@@ -29,6 +32,9 @@ function hasHeadingSlash(path) {
  * @memberof pathUtils
  */
 function hasTrailingSlash(path) {
+  if (path == null || path === '') {
+    return false;
+  }
   const match = matchSlashes(path);
   return (match[4] != null);
 }

--- a/src/util/path-utils.js
+++ b/src/util/path-utils.js
@@ -17,7 +17,7 @@ function matchSlashes(path) {
  * @returns {boolean}
  * @memberof pathUtils
  */
- function hasHeadingSlash(path) {
+function hasHeadingSlash(path) {
   if (path == null || path === '') {
     return false;
   }

--- a/src/util/path-utils.js
+++ b/src/util/path-utils.js
@@ -18,7 +18,7 @@ function matchSlashes(path) {
  * @memberof pathUtils
  */
 function hasHeadingSlash(path) {
-  if (path == null || path === '') {
+  if (path === '') {
     return false;
   }
   const match = matchSlashes(path);
@@ -32,7 +32,7 @@ function hasHeadingSlash(path) {
  * @memberof pathUtils
  */
 function hasTrailingSlash(path) {
-  if (path == null || path === '') {
+  if (path === '') {
     return false;
   }
   const match = matchSlashes(path);


### PR DESCRIPTION
PageCreateModalを空にするとエラーが出るのを修正しました。

<img width="708" alt="Screen Shot 2021-06-30 at 11 27 55" src="https://user-images.githubusercontent.com/66785624/123893119-c9450e80-d996-11eb-8c0a-b233cc84fd3b.png">